### PR TITLE
return copy of buffer

### DIFF
--- a/manifestgenerator/tspacket/tspacket.go
+++ b/manifestgenerator/tspacket/tspacket.go
@@ -165,7 +165,9 @@ func (p *TsPacket) AddData(buf []byte) {
 
 // GetBuffer Gets the buffer
 func (p *TsPacket) GetBuffer() []byte {
-	return p.buf
+	ret := make([]byte, len(p.buf))
+	copy(ret, p.buf)
+	return ret
 }
 
 // IsComplete Adds bytes to the packet


### PR DESCRIPTION
This fixes the http code path by not sharing the buffer across go routines which was causing corrupted writes